### PR TITLE
Update __init__.py

### DIFF
--- a/scanpy/plotting/_tools/__init__.py
+++ b/scanpy/plotting/_tools/__init__.py
@@ -92,6 +92,7 @@ def pca_loadings(
     adata: AnnData,
     components: Union[str, Sequence[int], None] = None,
     include_lowest: bool = True,
+    n_points=30,
     show: Optional[bool] = None,
     save: Union[str, bool, None] = None,
 ):
@@ -143,6 +144,7 @@ def pca_loadings(
         adata,
         'varm',
         'PCs',
+        n_points=n_points,
         indices=components,
         include_lowest=include_lowest,
     )


### PR DESCRIPTION
If the number of features(AKA genes) in adata.X is less than 30, sc.pl.pca_loadings shows duplicated entries.
This patch solves the problem by adding n_points parameter (defaults to 30, same value as in rankings)

<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
